### PR TITLE
Allow users to select EC2 instance type

### DIFF
--- a/APIM-with-Analytics/APIM-with-Analytics.yaml
+++ b/APIM-with-Analytics/APIM-with-Analytics.yaml
@@ -24,6 +24,7 @@ Metadata:
           - AWSAccessKeyId
           - AWSAccessKeySecret
           - KeyPairName
+          - WSO2InstanceType
       - Label:
           default: Network Configurations
         Parameters:
@@ -341,7 +342,7 @@ Resources:
         - WSO2PuppetMasterRegionMap
         - !Ref 'AWS::Region'
         - Ubuntu140464bit
-      InstanceType: t2.medium
+      InstanceType: !Ref WSO2InstanceType
       KeyName: !Ref KeyPairName
       Monitoring: 'false'
       Tags:
@@ -447,7 +448,7 @@ Resources:
         - WSO2APIMAMIRegionMap
         - !Ref 'AWS::Region'
         - Ubuntu140464bit
-      InstanceType: t2.medium
+      InstanceType: !Ref WSO2InstanceType
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -588,7 +589,7 @@ Resources:
         - WSO2APIMAMIRegionMap
         - !Ref 'AWS::Region'
         - Ubuntu140464bit
-      InstanceType: t2.medium
+      InstanceType: !Ref WSO2InstanceType
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -759,7 +760,7 @@ Resources:
         - WSO2APIMAnalyticsAMIRegionMap
         - !Ref 'AWS::Region'
         - Ubuntu140464bit
-      InstanceType: t2.medium
+      InstanceType: !Ref WSO2InstanceType
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -1125,6 +1126,25 @@ Parameters:
     Description: A previously uploaded certificate to use at the Load Balancer Listeners.
     Type: String
     MinLength: 1
+  WSO2InstanceType:
+    Description: EC2 instance type of the WSO2 nodes
+    Type: String
+    Default: t2.medium
+    AllowedValues:
+      - t2.nano
+      - t1.micro
+      - t2.micro
+      - t2.small
+      - t2.medium
+      - t2.large
+      - t2.xlarge
+      - t2.2xlarge
+      - m3.medium
+      - m3.large
+      - m3.xlarge
+      - m3.2xlarge
+      - m4.large
+    ConstraintDescription: Must be a valid EC2 instance type
   JDK:
     Type: String
     Default: "jdk-8u144-linux-x64.tar.gz"
@@ -1185,7 +1205,7 @@ Mappings:
     eu-west-2:
       Ubuntu140464bit: ami-to-be-added
     us-east-1:
-      Ubuntu140464bit: ami-035fc05c621b44c67
+      Ubuntu140464bit: ami-073c2167c4cd555fa
     us-east-2:
       Ubuntu140464bit: ami-to-be-added
     us-west-1:

--- a/APIM-with-Analytics/APIM-with-Analytics.yaml
+++ b/APIM-with-Analytics/APIM-with-Analytics.yaml
@@ -360,7 +360,6 @@ Resources:
           - |+
 
           - - '#!/bin/bash'
-            - set -e
             - 'export PATH=~/.local/bin:$PATH'
             - echo "> Set hostname to puppetmaster"
             - hostname puppetmaster
@@ -463,7 +462,6 @@ Resources:
           - |+
 
           - - '#!/bin/bash'
-            - set -e
             - 'export PATH=~/.local/bin:$PATH'
             - apt-get update
             - apt-get install -y nfs-common
@@ -604,7 +602,6 @@ Resources:
           - |+
 
           - - '#!/bin/bash'
-            - set -e
             - 'export PATH=~/.local/bin:$PATH'
             - apt-get update
             - apt-get install -y nfs-common
@@ -775,7 +772,6 @@ Resources:
           - |+
 
           - - '#!/bin/bash'
-            - set -e
             - 'export PATH=~/.local/bin:$PATH'
             - apt-get update
             - sed -i '/\[main\]/a server=puppet' /etc/puppet/puppet.conf
@@ -1205,7 +1201,7 @@ Mappings:
     eu-west-2:
       Ubuntu140464bit: ami-to-be-added
     us-east-1:
-      Ubuntu140464bit: ami-073c2167c4cd555fa
+      Ubuntu140464bit: ami-035fc05c621b44c67
     us-east-2:
       Ubuntu140464bit: ami-to-be-added
     us-west-1:

--- a/README.md
+++ b/README.md
@@ -9,17 +9,15 @@ This repository contains CloudFormation templates to deploy WSO2 API Manager wit
 git clone https://github.com/wso2/aws-apim.git
 ```
 
-2. Go to [AWS console](https://console.aws.amazon.com/ec2/v2/home#KeyPairs:sort=keyName) and specify a key value pair for authentication in **us-east-1** region. This could be used to ssh into the instances.
+2. Go to [AWS console](https://console.aws.amazon.com/ec2/v2/home#KeyPairs:sort=keyName) and specify a key value pair for authentication in **us-east-1** region. This could be used to ssh into the instances. Add a Server Certificate to AWS using ACM or IAM as explained [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html). This will be used at the load balancer listeners.
 
-3. Add a Server Certificate to AWS using ACM or IAM as explained [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html). This will be used at the load balancer listeners.
+3. Go to [AWS CloudFormation console](https://console.aws.amazon.com/cloudformation/home) and select ``Launch Cloudformer``.
 
-4. Go to [AWS CloudFormation console](https://console.aws.amazon.com/cloudformation/home) and select ``Launch Cloudformer``.
-
-5. Browse to the cloned repository and select the Cloudformation template for the preferred deployment pattern and proceed with the deployment.
+4. Browse to the cloned repository and select the Cloudformation template for the preferred deployment pattern and proceed with the deployment.
     <br> Available patterns are [APIM-with-Analytics](https://github.com/wso2/aws-apim/tree/master/APIM-with-Analytics).
-6. Follow the on screen instructions and provide the SSH key value pair name given in step 2, Server-Certificate-Name given in step 3 and other requested information and proceed.
+5. Follow the on screen instructions and provide the SSH key value pair name given in step 2, Server-Certificate-Name given in step 3 and other requested information and proceed.
 
-7. Access the web UIs via the URLs available in the **Outputs** tab and login using the following credentials.
+6. Access the web UIs via the URLs available in the **Outputs** tab and login using the following credentials.
    * Username: admin <br>
    * Password: admin
 


### PR DESCRIPTION
## Purpose
> Fixes #18 
> The current CF template is hardcoded to deploy APIM and Analytics in t2.medium EC2 instances. This PR allows the users to choose a preferred EC2 instance type.