### PR TITLE
Fix wso2-init.sh issue

### DIFF
--- a/pattern-1/pattern-1.yaml
+++ b/pattern-1/pattern-1.yaml
@@ -416,6 +416,7 @@ Resources:
               - - export ProductVersion=
                 - !Ref ProductVersion
             - service puppetmaster restart
+            - cd /home/ubuntu/
             - wget -O wso2-init.sh https://wso2-cloudformation-templates.s3.amazonaws.com/wso2-init.sh
             - chmod +x wso2-init.sh
             - !Sub "/home/ubuntu/wso2-init.sh wso2am-${ProductVersion}"


### PR DESCRIPTION
## Purpose
Change the download location of wso2-init.sh to /home/ubuntu/ 

## Goals
Change the download location of wso2-init.sh to /home/ubuntu/ 
